### PR TITLE
Dismiss IME on Back

### DIFF
--- a/main/java/com/brentandjody/stenoime/StenoIME.java
+++ b/main/java/com/brentandjody/stenoime/StenoIME.java
@@ -212,12 +212,23 @@ public class StenoIME extends InputMethodService implements TouchLayer.OnStrokeL
     }
 
     @Override
-    public boolean onKeyUp(int keyCode, KeyEvent event){
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (App.getMachineType() == StenoMachine.TYPE.VIRTUAL) {
+            // dismiss IME on back, otherwise ignore
+            return super.onKeyUp(keyCode, event);
+        } else {
             return dispatchKeyEvent(event);
+        }
     }
+
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        return dispatchKeyEvent(event);
+        if (App.getMachineType() == StenoMachine.TYPE.VIRTUAL) {
+            // dismiss IME on back, otherwise ignore
+            return super.onKeyDown(keyCode, event);
+        } else {
+            return dispatchKeyEvent(event);
+        }
     }
 
     @Override


### PR DESCRIPTION
This is inline with how other IMEs are handled; the first back should
dismiss the keyboard without passing the back button press to the app
underneath.

Before, pressing Back while editing would dismiss the keyboard AND 
press Back in the host app.
